### PR TITLE
Fix tag template error

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,7 +1,25 @@
+const { DateTime } = require('luxon');
+
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
     'src/assets/images': 'assets/images',
     'src/assets/js': 'assets/js'
+  });
+
+  eleventyConfig.addFilter('filterByTag', (posts, tag) => {
+    return (posts || []).filter(post => Array.isArray(post.data.tags) && post.data.tags.includes(tag));
+  });
+
+  eleventyConfig.addFilter('filterByCategory', (posts, category) => {
+    return (posts || []).filter(post => Array.isArray(post.data.categories) && post.data.categories.includes(category));
+  });
+
+  eleventyConfig.addFilter('date', (dateObj, format = 'yyyy-MM-dd') => {
+    if(!dateObj) {
+      return '';
+    }
+    let dt = (dateObj instanceof Date) ? DateTime.fromJSDate(dateObj) : DateTime.fromISO(dateObj.toString());
+    return dt.toFormat(format);
   });
 
   return {

--- a/src/_layouts/category.njk
+++ b/src/_layouts/category.njk
@@ -3,7 +3,7 @@
 {% block content %}
   <h1>カテゴリ: {{ category }}</h1>
   <div class="post-list">
-    {% for post in collections.posts | filter(post => post.data.categories && post.data.categories.includes(category)) %}
+  {% for post in collections.posts | filterByCategory(category) %}
       <article class="post-card">
         <a href="{{ post.url }}">
           {% if post.data.thumbnail %}

--- a/src/_layouts/tag.njk
+++ b/src/_layouts/tag.njk
@@ -3,7 +3,7 @@
 {% block content %}
   <h1>タグ: {{ tag }}</h1>
   <div class="post-list">
-    {% for post in collections.posts | filter(post => post.data.tags && post.data.tags.includes(tag)) %}
+  {% for post in collections.posts | filterByTag(tag) %}
       <article class="post-card">
         <a href="{{ post.url }}">
           {% if post.data.thumbnail %}


### PR DESCRIPTION
## Summary
- add custom filters for categories and tags
- add a date format filter using Luxon
- use these filters in category and tag templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68418311301c8322ad085fb31a89d6aa